### PR TITLE
Home page layout

### DIFF
--- a/home.css
+++ b/home.css
@@ -7,6 +7,12 @@
 :root {
     --bg: #2E6F40;
     --fg: #EEEEEE;
+
+    --descr: #eee;
+    --image: #33f;
+
+    /* from INSTRUCTIONS */
+    --palette-1: #89ff76;
 }
 
 .root {
@@ -14,7 +20,13 @@
         "Calibri", "Trebuchet MS", sans-serif;
     width: 75%;
     margin: 5em auto; /* magic constant for position:fixed */
-    h1, h2 { margin: 0; }
+    h1, h2, p { margin: 0; }
+    h1 { font-size: 2.4em; }
+    h2 { font-size: 1.8em; }
+    /* use a different box model for every child element
+     * from here on. this is so i don't have to say
+     * <width> = <actual-width> - <2*padding> */
+    * { box-sizing: border-box; }
 }
 
 .intro {
@@ -24,6 +36,57 @@
 
     * { text-align: center; }
 
-    .title    { font-size: 3em; }
-    .subtitle { font-size: 1.2em; }
+    .title    { font-weight: bold; font-size: 3em; }
+    .subtitle { font-weight: bold; font-size: 1.2em; }
 }
+
+.flashy {
+    display: flex;
+    /*
+     * so uh stack these side by side:
+     *
+     *      |
+     *      |                        +- image --------+    \
+     *      |  +- descr --------+    |  @@@@@@@@@@@@  |     |
+     *  cross  | == Title ==    |    |  @@@@@@@@@@@@  |     | ... align these
+     *      +-------- main -------->-------- axis ------->  | guys, in the
+     *   axis  | text text ...  |    |  @@@@@@@@@@@@  |     | event we have
+     *      |  +----------------+    |  @@@@@@@@@@@@  +     | less text/image
+     *      |                   `    +----------------+     |
+     *      v                    \  /'                     /
+     *                            \/
+     *        use space-between to lazily spread this thing
+     *    b/c i don't want to (and probably can't) do math in CSS
+     *
+     */
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+
+    .image-box { background-color: var(--image); min-width: 40%; min-height: 6em; }
+    .descr-box { background-color: var(--descr); min-width: 56%; min-height: 4em; }
+    .form-descr-box { background-color: var(--descr); min-width: 46%; min-height: 4em; }
+    .form-box { background-color: var(--palette-1); min-width: 50%; min-height: 4em; }
+
+    form {
+        display: flex;
+        flex-direction: column;
+        align-items: start; /* left alignment */
+        gap: 2em; /* space between rows */
+
+        .row { display: flex; flex-direction: row; gap: 0.5em; }
+        .full .row { min-width: 100%; }
+        .field { display: flex; flex-direction: column; }
+
+        label { /* no style */ }
+        input[type=text] { /* no style */ }
+        input[type=button] { /* no style */ }
+        textarea { max-width: 100%; resize: vertical; }
+    }
+
+    .image-box, .descr-box, .form-box, .form-descr-box { padding: 2em; }
+}
+
+/* reap the sweet sweet berries of margin collapse... >:] */
+.intro, .flashy { margin: 2em 0; }

--- a/home.css
+++ b/home.css
@@ -1,0 +1,29 @@
+@charset "UTF-8";
+
+/*
+ * i am basing my colors and fonts on
+ * bd0b9d5ce99c3f1f0256088ffb05f1bff1e5a059:style.css
+ */
+:root {
+    --bg: #2E6F40;
+    --fg: #EEEEEE;
+}
+
+.root {
+    font: 16px/1.875 "Gill Sans", "Gill Sans MT",
+        "Calibri", "Trebuchet MS", sans-serif;
+    width: 75%;
+    margin: 5em auto; /* magic constant for position:fixed */
+    h1, h2 { margin: 0; }
+}
+
+.intro {
+    background-color: var(--bg);
+    color: var(--fg);
+    padding: 2em;
+
+    * { text-align: center; }
+
+    .title    { font-size: 3em; }
+    .subtitle { font-size: 1.2em; }
+}

--- a/home.html
+++ b/home.html
@@ -6,10 +6,21 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>CodeForGood</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="home.css">
 </head>
 <body>
 
     <div id="banner-container"></div>
+    <div class="root">
+        <div class="intro">
+            <h1 class="title">
+                CodeForGood
+            </h1>
+            <h2 class="subtitle">
+                I might be abusing the font but I don't really know
+            </h2>
+        </div>
+    </div>
 
     <script>
         // Load header.html content into the banner-container div

--- a/home.html
+++ b/home.html
@@ -16,9 +16,90 @@
             <h1 class="title">
                 CodeForGood
             </h1>
-            <h2 class="subtitle">
-                I might be abusing the font but I don't really know
-            </h2>
+            <p class="subtitle">
+                A student organization that is pretty cool :)
+            </p>
+        </div>
+
+        <div class="flashy">
+            <div class="descr-box">
+                <h2>This is what we do</h2>
+                <p>
+<!-- Instead of Lorem ipsum, let's have something fun :) -->
+            <em>  A lonely pond in age-old stillness sleeps &hellip;
+            <br>    Apart, unstirred by sound or motion &hellip; till
+            <br>    Suddenly! into it a lithe frog leaps.
+            </em> <!--
+Basho's haiku, into iambic pentameter!
+     ... by Curtis Hidden Page:
+     https://www.bopsecrets.org/gateway/passages/basho-frog.htm
+-->             </p>
+                <p>[read more about us in <a href="about.html">About</a>]</p>
+            </div>
+            <div class="image-box">
+                <p style="color:#eee;">[fancy.png]</p>
+            </div>
+        </div>
+
+        <div class="flashy">
+            <div class="form-box"><form action="home.html" method="GET">
+                <div class="row">
+                    <div class="field">
+                        <label>Who are you?????</label>
+                        <input type="text" name="name">
+                    </div>
+                    <div class="field">
+                        <label>OK!!!! and ur electronic mail???</label>
+                        <input type="text" name="mail">
+                    </div>
+                </div>
+                <div class="full row">
+                    <div class="field">
+                        <label>LAST QUESTION! before you [REDACTED], what do you think of life???</label>
+                        <textarea rows="4" cols="76" name="etc"></textarea>
+                    </div>
+                </div>
+                <div class="row">
+                    <button type="submit">SUBMIT!!!</button>
+                </div>
+            </form></div>
+            <div class="form-descr-box">
+                <h2>Fun things to do</h2>
+                <p>Contact / subscribe to / detonate us</p>
+                <p>:))))))))))))))))))))</p>
+                <p>&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;<!--
+-->&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;</p>
+            </div>
+
+            <!-- Realistically, we (the client) will not be the one
+                 handling the ultimate submission (it might not
+                 even be sent to this route).  This exists only as
+                 a proof of concept that this form works, it can send
+                 data... but for now it just appends the parameters
+                 to the request URI of our same silly GET request. -->
+            <script type="text/javascript">
+                let query = window.location.search;
+                if (query.charAt(0) === '?') {
+                    /* don't judge me for using String.prototype.substring...
+                        I'm from Javaland, and I'm more used to it than slice :,) */
+                    let params = query.substring(1).split('&');
+                    let paramstr = '';
+                    for (let i = 0; i < params.length; ++i) {
+                        let fields = params[i].split('=');
+                        paramstr += fields[0];
+                        paramstr += ': ';
+                        paramstr += decodeURIComponent(fields[1]).replaceAll('+', ' ');
+                        paramstr += "\n";
+                    }
+                    window.alert("Hey, I got your form submission!\n"
+                        + "Here's what you sent to me:\n\n"
+                        + paramstr + "\n"
+                        + "Note that all of this information comes from "
+                        + "the query string of your request URI.  To stop this "
+                        + "pop-up from showing up, delete it from your URI."
+                    );
+                }
+            </script>
         </div>
     </div>
 


### PR DESCRIPTION
This adds some very barebone layout for `home.html` (see 53d41eb9501b1095861ee2eba430b8988e29ee44). Fonts and colors are largely taken from #4

The stylesheet makes heavy use of the [CSS3 nesting module](https://drafts.csswg.org/css-nesting/), which may appear like a Sass extension but is actually a [surprisingly well-supported native CSS feature][nesting].

[nesting]: https://caniuse.com/css-nesting

```
$ git request-pull upstream/main https://github.com/eyzmeng/CodeForGoodWebsite.git home-page-layout
The following changes since commit 0c08110e372230bd8fb7ca9eb7dd5aba5e4df1e6:

  Fixed Additional File (2024-10-29 18:30:45 -0500)

are available in the Git repository at:

  https://github.com/eyzmeng/CodeForGoodWebsite.git home-page-layout

for you to fetch changes up to 53d41eb9501b1095861ee2eba430b8988e29ee44:

  Add two rows to the home page (2025-01-06 20:21:39 +0800)

----------------------------------------------------------------
Ethan Meng (2):
      Try out title for home page
      Add two rows to the home page

 home.css  | 92 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 home.html | 92 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 184 insertions(+)
 create mode 100644 home.css
```